### PR TITLE
Change type of APS sound/category to Cow<'static, str>

### DIFF
--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use request::notification::{NotificationBuilder, NotificationOptions};
 use request::payload::{APSAlert, Payload, APS};
 
@@ -47,8 +48,8 @@ pub struct LocalizedAlert {
 pub struct LocalizedNotificationBuilder {
     alert: LocalizedAlert,
     badge: Option<u32>,
-    sound: Option<String>,
-    category: Option<String>,
+    sound: Option<Cow<'static, str>>,
+    category: Option<Cow<'static, str>>,
     mutable_content: u8,
 }
 
@@ -81,18 +82,18 @@ impl LocalizedNotificationBuilder {
     }
 
     /// File name of the custom sound to play when receiving the notification.
-    pub fn set_sound<S>(&mut self, sound: S)
+    pub fn set_sound<C>(&mut self, sound: C)
     where
-        S: Into<String>,
+        C: Into<Cow<'static, str>>,
     {
         self.sound = Some(sound.into());
     }
 
     /// When a notification includes the category key, the system displays the
     /// actions for that category as buttons in the banner or alert interface.
-    pub fn set_category<S>(&mut self, category: S)
+    pub fn set_category<C>(&mut self, category: C)
     where
-        S: Into<String>,
+        C: Into<Cow<'static, str>>,
     {
         self.category = Some(category.into());
     }
@@ -196,12 +197,16 @@ mod tests {
         assert_eq!(expected_payload, payload);
     }
 
+    static SOUND: &'static str = "pröötprööt";
+
     #[test]
     fn test_localized_notification_with_full_data() {
         let mut builder = LocalizedNotificationBuilder::new("the title", "the body");
 
         builder.set_badge(420);
         builder.set_category("cat1");
+        builder.set_sound(SOUND);
+        builder.set_sound("prööt".to_string());
         builder.set_sound("prööt");
         builder.set_mutable_content();
         builder.set_action_loc_key("PLAY");

--- a/src/request/notification/plain.rs
+++ b/src/request/notification/plain.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use request::notification::{NotificationBuilder, NotificationOptions};
 use request::payload::{APSAlert, Payload, APS};
 
@@ -20,8 +21,8 @@ use request::payload::{APSAlert, Payload, APS};
 pub struct PlainNotificationBuilder {
     body: String,
     badge: Option<u32>,
-    sound: Option<String>,
-    category: Option<String>,
+    sound: Option<Cow<'static, str>>,
+    category: Option<Cow<'static, str>>,
 }
 
 impl PlainNotificationBuilder {
@@ -43,18 +44,18 @@ impl PlainNotificationBuilder {
     }
 
     /// File name of the custom sound to play when receiving the notification.
-    pub fn set_sound<S>(&mut self, sound: S)
+    pub fn set_sound<C>(&mut self, sound: C)
     where
-        S: Into<String>,
+        C: Into<Cow<'static, str>>,
     {
         self.sound = Some(sound.into());
     }
 
     /// When a notification includes the category key, the system displays the
     /// actions for that category as buttons in the banner or alert interface.
-    pub fn set_category<S>(&mut self, category: S)
+    pub fn set_category<C>(&mut self, category: C)
     where
-        S: Into<String>,
+        C: Into<Cow<'static, str>>,
     {
         self.category = Some(category.into());
     }
@@ -101,10 +102,14 @@ mod tests {
         assert_eq!(expected_payload, payload);
     }
 
+    static CATEGORY: &'static str = "catcat";
+
     #[test]
     fn test_plain_notification_with_full_data() {
         let mut builder = PlainNotificationBuilder::new("Hi there");
         builder.set_badge(420);
+        builder.set_category(CATEGORY);
+        builder.set_category("cat1".to_string());
         builder.set_category("cat1");
         builder.set_sound("prööt");
 

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -3,6 +3,7 @@
 use request::notification::{LocalizedAlert, NotificationOptions};
 use error::Error;
 use serde_json::{self, Map, Value};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use erased_serde::Serialize;
 
@@ -67,7 +68,7 @@ pub struct APS {
 
     /// The name of the sound file to play when user receives the notification.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sound: Option<String>,
+    pub sound: Option<Cow<'static, str>>,
 
     /// Set to one for silent notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -76,7 +77,7 @@ pub struct APS {
     /// When a notification includes the category key, the system displays the
     /// actions for that category as buttons in the banner or alert interface.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub category: Option<String>,
+    pub category: Option<Cow<'static, str>>,
 
     /// If set to one, the app can change the notification content before
     /// displaying it to the user.


### PR DESCRIPTION
This way a static sound and category can be specified, thus avoiding an allocation for every notification.

The API is still ergonomic, thanks to `Into<Cow<'static, str>>`.

A question would be whether to use custom lifetimes instead of 'static, but then those lifetimes would propagate through the entire type hierarchy. Not sure if you want that.