### PR TITLE
Show APNS error reason in Display impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use serde_json::Error as SerdeError;
 use openssl::error::ErrorStack;
 use std::fmt;
 use std::convert::From;
-use response::Response;
+use response::{Response, ErrorBody};
 
 #[derive(Debug)]
 pub enum Error {
@@ -24,7 +24,12 @@ pub enum Error {
 
 impl<'a> fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        match self {
+            &Error::ResponseError(Response { error: Some(ErrorBody { ref reason, .. }), .. }) => {
+                write!(fmt, "{} (reason: {:?})", self.description(), reason)
+            },
+            _ => write!(fmt, "{}", self.description()),
+        }
     }
 }
 


### PR DESCRIPTION
If the error is a ResponseError that contains an error reason (as sent by Apple), then show it in the fmt::Display impl.

This helps a lot when debugging.

Example output:

> Notification was not accepted by APNs (reason: BadDeviceToken)